### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/_tasks.erb
+++ b/_tasks.erb
@@ -1,6 +1,6 @@
 <%- if bundler? -%>
 require 'yard'
-YARD::Rake::YardocTask.new  
+YARD::Rake::YardocTask.new
 <%- else -%>
 begin
   require 'yard'


### PR DESCRIPTION
Hi,

Thank you for flexible gem template tool!

But I always remove trailing whitespaces in Rakefile. Could you merge this patch?